### PR TITLE
removes scrollbars from ui

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 	{background-color: #f5f6ff;
 	 margin:0;
 	 padding:0;}
+	  
+	 body { overflow: hidden; }
   </style>
 
 


### PR DESCRIPTION
The scrollbars can be removed from the UI with an `overflow: hidden;` on body

Changes

![image](https://user-images.githubusercontent.com/77482/136815428-3d23837e-c041-46af-9b7b-8eb561770dad.png)

into

![image](https://user-images.githubusercontent.com/77482/136815575-2c43cf5c-edf8-446b-af88-b38667784d2c.png)

The scrollbars caused their own problems too.  By example, prior to this patch, because canvas was sized to the inner region, the scrollbar appearance meant the page could be horizontally scrolled by the width of a scrollbar

One would not be able to see this on a Mac because of Apple's nonstandard scrollbars